### PR TITLE
Fix display of JSON-format string message bodies

### DIFF
--- a/iothub-explorer-monitor-events.js
+++ b/iothub-explorer-monitor-events.js
@@ -57,7 +57,7 @@ ehClient.open()
                   if (eventData.body instanceof Buffer) {
                     console.log(eventData.body.toString());
                   } else if (typeof eventData.body === 'string') {
-                    console.log(eventData instanceof Buffer ? eventData.body.toString() : JSON);
+                    console.log(JSON.stringify(eventData.body));
                   } else {
                     if (!raw) {
                       console.log(JSON.stringify(eventData.body, null, 2));


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/iothub-explorer/blob/master/.github/CONTRIBUTING.md).

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Message bodies that could be parsed as UTF-8 encoded JSON strings were being shown in the output as an empty pair of braces {} because the actual global JSON object itself was being printed, not the body of the message.

# Description of the solution
Correct the call to JSON.stringify() that was probably only missing due to a typo.
