### PR TITLE
Fix numeric args to create, login, monitor-events commands

### DIFF
--- a/iothub-explorer-create.js
+++ b/iothub-explorer-create.js
@@ -28,7 +28,7 @@ program
   .option('-k2, --key2 <key>', 'specify the secondary key for newly created device')
   .option('-r, --raw', 'use this flag to return raw JSON instead of pretty-printed output')
   .option('-x, --x509', 'generate an x509 certificate to authenticate the device')
-  .option('-dv, --daysValid', 'number of days the x509 certificate should be valid for')
+  .option('-dv, --daysValid', 'number of days the x509 certificate should be valid for', parseInt)
   .option('-t1, --thumbprint1 <thumbprint>', 'specify the primary thumbprint of the x509 certificate')
   .option('-t2, --thumbprint2 <thumbprint>', 'specify the secondary thumbprint of the x509 certificate')
   .parse(process.argv);

--- a/iothub-explorer-login.js
+++ b/iothub-explorer-login.js
@@ -22,7 +22,7 @@ var SharedAccessSignature = require('azure-iothub').SharedAccessSignature;
 
 program
   .description('Create a temporary session on your IoT hub')
-  .option('-d, --duration <duration-in-seconds>', 'time to keep the session open for (in seconds): if not specified, the default is one hour')
+  .option('-d, --duration <duration-in-seconds>', 'time to keep the session open for (in seconds): if not specified, the default is one hour', parseInt)
   .parse(process.argv);
 
 if(!program.args[0]) inputError('You must specify a connection string.');

--- a/iothub-explorer-monitor-events.js
+++ b/iothub-explorer-monitor-events.js
@@ -38,7 +38,9 @@ if(!program.raw) {
 }
 
 var consumerGroup = program.consumerGroup || '$Default';
-var startTime = program.startTime ? new Date(program.startTime) : Date.now();
+var startTime = program.startTime ?
+  isNaN(program.startTime) ? new Date(program.startTime) : new Date(parseInt(program.startTime)) :
+  Date.now();
 
 var ehClient = EventHubsClient.fromConnectionString(connectionString);
 ehClient.open()

--- a/iothub-explorer-sas-token.js
+++ b/iothub-explorer-sas-token.js
@@ -21,14 +21,14 @@ var Registry = require('azure-iothub').Registry;
 program
   .description('Generate a shared access signature token for the given device with an expiry time <num-seconds> from now')
   .option('-l, --login <connectionString>', 'use the connection string provided as argument to use to authenticate with your IoT hub')
-  .option('-d, --duration <durationInSeconds>', 'expiration time (in seconds): if not specified, the default is one hour')
+  .option('-d, --duration <durationInSeconds>', 'expiration time (in seconds): if not specified, the default is one hour', parseInt)
   .parse(process.argv);
 
 if(!program.args[0]) inputError('You must specify a device id.');
 
 var deviceId = program.args[0];
 var nowInSeconds = Math.floor(Date.now() / 1000);
-var expiry = program.duration ? nowInSeconds + parseInt(program.duration) : nowInSeconds + 3600;
+var expiry = program.duration ? nowInSeconds + program.duration : nowInSeconds + 3600;
 
 if (isNaN(new Date(expiry * 1000))) {
   inputError('Invalid duration');


### PR DESCRIPTION
The create, login, and monitor-events commands were interpreting certain numeric args as strings instead of integers, which, when specified, caused the commands to fail (actually, create happened to work but I updated it for consistency). With this fix the arguments are now parsed as integers, so you can: specify a --daysValid value when creating a device with an X509 cert; specify a --duration value when using "login" to start a session; specify a --start-time (as milliseconds since epoch OR as ISO-8601 string--I verified both) when monitoring events for a device.

The --duration arg to sas-token was already correct, but I updated it for consistency. I believe the "best practice" is to pass the parsing function to commander.option() if possible, then fall back to manual parsing if needed (monitor-events --start-time is an example of an overloaded arg that needs to be parsed manually).