### PR TITLE
Only monitor events for a valid device ID (#30)

### DIFF
--- a/iothub-explorer-monitor-events.js
+++ b/iothub-explorer-monitor-events.js
@@ -4,6 +4,8 @@
 
 'use strict';
 
+var Registry = require('azure-iothub').Registry;
+
 // external dependencies
 var program = require('commander');
 var colorsTmpl = require('colors-tmpl');
@@ -24,83 +26,98 @@ program
   .option('-st, --start-time <start-time>', 'Specify the time that should be used as a starting point to read messages in the partitions (number of milliseconds since epoch or ISO-8601 string)')
   .parse(process.argv);
 
-if(!program.login) inputError('You must provide a connection string using the --login argument.');
+if (!program.login) inputError('You must provide a connection string using the --login argument.');
 
 var deviceId = program.args[0];
 var connectionString = program.login;
 
-if(!program.raw) {
-  if (deviceId) {
-    console.log(colorsTmpl('\n{grey}Monitoring events from device {green}' + deviceId + '{/green}...{/grey}'));
-  } else {
-    console.log(colorsTmpl('\n{grey}Monitoring events from all devices...{/grey}'));
+var monitorEvents = function () {
+  if (!program.raw) {
+    if (deviceId) {
+      console.log(colorsTmpl('\n{grey}Monitoring events from device {green}' + deviceId + '{/green}...{/grey}'));
+    } else {
+      console.log(colorsTmpl('\n{grey}Monitoring events from all devices...{/grey}'));
+    }
   }
-}
 
-var consumerGroup = program.consumerGroup || '$Default';
-var startTime = program.startTime ? new Date(program.startTime) : Date.now();
+  var consumerGroup = program.consumerGroup || '$Default';
+  var startTime = program.startTime ? new Date(program.startTime) : Date.now();
 
-var ehClient = EventHubsClient.fromConnectionString(connectionString);
-ehClient.open()
-        .then(ehClient.getPartitionIds.bind(ehClient))
-        .then(function (partitionIds) {
-          return partitionIds.map(function (partitionId) {
-            return ehClient.createReceiver(consumerGroup, partitionId, { 'startAfterTime' : startTime}).then(function(receiver) {
-              receiver.on('errorReceived', function (error) {
-                serviceError(error.message);
-              });
-              receiver.on('message', function (eventData) {
-                var from = eventData.annotations['iothub-connection-device-id'];
-                var raw = program.raw;
-                if (!deviceId || (deviceId && from === deviceId)) {
-                  if (!raw) console.log('==== From: ' + from + ' ====');
-                  if (eventData.body instanceof Buffer) {
-                    console.log(eventData.body.toString());
-                  } else if (typeof eventData.body === 'string') {
-                    console.log(JSON.stringify(eventData.body));
-                  } else {
-                    if (!raw) {
-                      console.log(JSON.stringify(eventData.body, null, 2));
-                    } else {
-                      console.log(JSON.stringify(eventData.body));
-                    }
-                  }
-
-                  if (program.verbose) {
-                    if (eventData.annotations) {
-                      if (!raw) {
-                        console.log('---- annotations ----');
-                        console.log(JSON.stringify(eventData.annotations, null, 2));
-                      } else {
-                        console.log(JSON.stringify(eventData.annotations));
-                      }
-                    }
-
-                    if (eventData.properties) {
-                      if (!raw) {
-                        console.log('---- properties ----');
-                        console.log(JSON.stringify(eventData.properties, null, 2));
-                      } else {
-                        console.log(JSON.stringify(eventData.properties));
-                      }
-                    }
-                  }
-
-                  if (eventData.applicationProperties) {
-                    if (!raw) {
-                      console.log('---- application properties ----');
-                      console.log(JSON.stringify(eventData.applicationProperties, null, 2));
-                    } else {
-                      console.log(JSON.stringify(eventData.applicationProperties));
-                    }
-                  }
-
-                  if (!raw) console.log('====================');
-                }
-              });
-            });
+  var ehClient = EventHubsClient.fromConnectionString(connectionString);
+  ehClient.open()
+    .then(ehClient.getPartitionIds.bind(ehClient))
+    .then(function (partitionIds) {
+      return partitionIds.map(function (partitionId) {
+        return ehClient.createReceiver(consumerGroup, partitionId, { 'startAfterTime': startTime }).then(function (receiver) {
+          receiver.on('errorReceived', function (error) {
+            serviceError(error.message);
           });
-        })
-        .catch(function (error) {
-          serviceError(error.message);
+          receiver.on('message', function (eventData) {
+            var from = eventData.annotations['iothub-connection-device-id'];
+            var raw = program.raw;
+            if (!deviceId || (deviceId && from === deviceId)) {
+              if (!raw) console.log('==== From: ' + from + ' ====');
+              if (eventData.body instanceof Buffer) {
+                console.log(eventData.body.toString());
+              } else if (typeof eventData.body === 'string') {
+                console.log(JSON.stringify(eventData.body));
+              } else {
+                if (!raw) {
+                  console.log(JSON.stringify(eventData.body, null, 2));
+                } else {
+                  console.log(JSON.stringify(eventData.body));
+                }
+              }
+
+              if (program.verbose) {
+                if (eventData.annotations) {
+                  if (!raw) {
+                    console.log('---- annotations ----');
+                    console.log(JSON.stringify(eventData.annotations, null, 2));
+                  } else {
+                    console.log(JSON.stringify(eventData.annotations));
+                  }
+                }
+
+                if (eventData.properties) {
+                  if (!raw) {
+                    console.log('---- properties ----');
+                    console.log(JSON.stringify(eventData.properties, null, 2));
+                  } else {
+                    console.log(JSON.stringify(eventData.properties));
+                  }
+                }
+              }
+
+              if (eventData.applicationProperties) {
+                if (!raw) {
+                  console.log('---- application properties ----');
+                  console.log(JSON.stringify(eventData.applicationProperties, null, 2));
+                } else {
+                  console.log(JSON.stringify(eventData.applicationProperties));
+                }
+              }
+
+              if (!raw) console.log('====================');
+            }
+          });
         });
+      });
+    })
+    .catch(function (error) {
+      serviceError(error.message);
+    });
+};
+
+if (deviceId) {
+  var registry = Registry.fromConnectionString(connectionString);
+  registry.get(deviceId, function (err) {
+    if (err) serviceError(err);
+    else {
+      monitorEvents();
+    }
+  });
+}
+else {
+  monitorEvents();
+}


### PR DESCRIPTION
# Reference/Link to the issue solved with this PR (if any)
Solves #30 

# Description of the problem
`iothub-explorer` will happily monitor events for a device that doesn't exist:

```
$ iothub-explorer monitor-events i-do-not-exist -l "{connection-string}"

Monitoring events from device i-do-not-exist...
```

# Description of the solution
Now the `monitor-events` command checks that the device exists before setting up the event monitor. If it does not exist, the command fails:

```
$ iothub-explorer monitor-events i-do-not-exist -l "{connection-string}"

Error: DeviceNotFoundError: i-do-not-exist
```
