### PR TITLE
Add 'duration' option to 'monitor-events' command

### DIFF
--- a/iothub-explorer-monitor-events.js
+++ b/iothub-explorer-monitor-events.js
@@ -40,7 +40,7 @@ program
   .option('-v, --verbose', 'Show more information from the received event, including annotations and properties')
   .option('-c, --consumer-group <consumer-group>', 'Use the provided consumer group when connecting to Event Hubs')
   .option('-s, --start-time <start-time>', 'Read messages that arrived on or after the given time (milliseconds since epoch or ISO-8601 string)')
-  .option('-d, --duration <duration>', 'Exit aften the given number of seconds (runs indefinitely if not specified)', coerceAndValidateDuration)
+  .option('-d, --duration <duration>', 'Exit after the given number of seconds (runs indefinitely if not specified)', coerceAndValidateDuration)
   .parse(process.argv);
 
 if (!program.login) inputError('You must provide a connection string using the --login argument.');

--- a/iothub-explorer-monitor-events.js
+++ b/iothub-explorer-monitor-events.js
@@ -19,11 +19,12 @@ var EventHubsClient = require('azure-event-hubs').Client;
 
 program
   .description('Monitor messages sent by devices to the IoT hub')
-  .option('-l, --login <connectionString>', 'use the connection string provided as argument to use to authenticate with your IoT hub')
-  .option('-r, --raw', 'use this flag to return raw output instead of pretty-printed output')
-  .option('-v, --verbose', 'shows all the information contained in the event received, including annotations and properties')
-  .option('-c, --consumer-group <consumer-group>', 'Specify the consumer group to use when connecting to Event Hubs partitions')
-  .option('-s, --start-time <start-time>', 'Specify the time that should be used as a starting point to read messages in the partitions (number of milliseconds since epoch or ISO-8601 string)')
+  .option('-l, --login <connectionString>', 'Use the provided connection string to authenticate with IoT Hub')
+  .option('-r, --raw', 'Return raw output instead of pretty-printed output (useful for automation)')
+  .option('-v, --verbose', 'Show more information from the received event, including annotations and properties')
+  .option('-c, --consumer-group <consumer-group>', 'Use the provided consumer group when connecting to Event Hubs')
+  .option('-s, --start-time <start-time>', 'Read messages that arrived on or after the given time (milliseconds since epoch or ISO-8601 string)')
+  .option('-d, --duration <duration>', 'Exit aften the given number of seconds (runs indefinitely if not specified)')
   .parse(process.argv);
 
 if (!program.login) inputError('You must provide a connection string using the --login argument.');


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/iothub-explorer/blob/master/.github/CONTRIBUTING.md).

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
I'm writing an automated script which, among other things, needs to monitor events being sent to an IoT hub for a specific period of time (e.g., 30 seconds). Rather than writing shell code to launch iothub-explorer, get its PID, then kill it, it would be great if I could simply tell the monitor-events command to close after some number of seconds.

# Description of the solution
These changes add a `--duration` option to monitor-events, which takes a number representing seconds. If specified, the tool will close after the given # of seconds have elapsed.