### PR TITLE
Changed single quotes to double

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,7 @@ $ iothub-explorer delete existing-device
 Use the following command to monitor the device-to-cloud messages from a device:
 
 ```shell
-$ iothub-explorer monitor-events myFirstDevice --login 'HostName=<my-hub>.azure-devices.net;SharedAccessKeyName=<my-policy>;SharedAccessKey=<my-policy-key>'
+$ iothub-explorer monitor-events myFirstDevice --login "HostName=<my-hub>.azure-devices.net;SharedAccessKeyName=<my-policy>;SharedAccessKey=<my-policy-key>"
 
 Monitoring events from device myFirstDevice
 Listening on endpoint iothub-ehub-<my-endpoint>/ConsumerGroups/$Default/Partitions/0 start time: 1453821103646


### PR DESCRIPTION
The one example I changed used single quotes, which fails in some terminals. I switched to double quotes. This also makes it match the rest of the examples.

<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/iothub-explorer/blob/master/.github/CONTRIBUTING.md).

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
