### PR TITLE
fixed missing parameter of protocol 'mqtt-ws' in condition

### DIFF
--- a/iothub-explorer-simulate-device.js
+++ b/iothub-explorer-simulate-device.js
@@ -54,7 +54,7 @@ function verifySettle(arg) {
 
 function verifyProtocol(arg) {
   var lowerCaseArg = arg.toLowerCase();
-  if (lowerCaseArg !== 'amqp' && lowerCaseArg !== 'amqp-ws' && lowerCaseArg !== 'http' && lowerCaseArg !== 'mqtt') {
+  if (lowerCaseArg !== 'amqp' && lowerCaseArg !== 'amqp-ws' && lowerCaseArg !== 'http' && lowerCaseArg !== 'mqtt' && lowerCaseArg !== 'mqtt-ws') {
     inputError('--protocol can take only take one of the following values: \'amqp\', \'amqp-ws\', \'mqtt\', \'mqtt-ws\' or \'http\'');
   } else {
     return lowerCaseArg;


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/iothub-explorer/blob/master/.github/CONTRIBUTING.md).

# Description of the problem
The following error riases when using command iothub-explorer -simulate-device with protocol 'mqtt-ws' even if this protocol is supported and right.
Here is error message:

> PS C:\> _iothub-explorer simulate-device MyFirstDevice --send --protocol mqtt-ws_
_> Input Error: --protocol can take only take one of the following values: 'amqp', 'amqp-ws', 'mqtt', 'mqtt-ws' or 'http'_

In code there is only missing 1 condition on line 57 in function function _verifyProtocol()_

# Description of the solution

Resolution is very easy just added small piece of code on line 57:
`&& lowerCaseArg !== 'mqtt-ws'`

